### PR TITLE
Fixed broken link for GCP file format documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See `odm --help` for more options.
 
 ## Using GCPs
 
-To include a GCP for additional georeferencing accuracy, simply create a .txt file according to the [Ground Control Points format specification](https://docs.opendronemap.org/using.html#ground-control-points) and place it along with the images.
+To include a GCP for additional georeferencing accuracy, simply create a .txt file according to the [Ground Control Points format specification](https://docs.opendronemap.org/gcp.html#gcp-file-format) and place it along with the images.
 
 ## Processing Node Management
 


### PR DESCRIPTION
The link was old/broken, I updated it to the correct link. FIxes issue #10 